### PR TITLE
Fix duplicate listener issue

### DIFF
--- a/layouts/shortcodes/yt.html
+++ b/layouts/shortcodes/yt.html
@@ -90,6 +90,11 @@
 
 <script>
 document.querySelectorAll('.video-wrapper').forEach(wrapper => {
+  if (wrapper.dataset.listenersAdded === 'true') {
+    return;
+  }
+  wrapper.dataset.listenersAdded = 'true';
+
   const videoId = wrapper.dataset.videoId;
   const overlay = wrapper.querySelector('.video-overlay');
   const thumbnail = wrapper.querySelector('.video-thumbnail');


### PR DESCRIPTION
## Summary
- avoid registering multiple event listeners when embedding more than one YouTube video

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687df0e9ea5c8328a88d23b50410a517