### PR TITLE
feat: add optional rounded thumbnail corners

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Example page to [see the plugin in action](https://fischr.org/2018/08/26/gardase
 This plugin offers the following optional settings:
 - Custom CSS Class – Adds a custom class to the video container for styling
 - Privacy notice on/off – Decide whether you want to show the privacy disclaimer
-- Privacy notice text – Allows you to customize the disclaimer text 
+- Privacy notice text – Allows you to customize the disclaimer text
+- Rounded thumbnail corners – Display video previews with rounded edges
 
 All settings can be configured in the Micro.blog plugin settings panel.
 
@@ -36,3 +37,8 @@ All settings can be configured in the Micro.blog plugin settings panel.
 - [fmaida/mbplugin-youtube](https://github.com/fmaida/mbplugin-youtube)
 - [shindakun/mbplugin-bandcamp](https://github.com/shindakun/mbplugin-bandcamp)
 - [embedresponsively.com](http://embedresponsively.com)
+
+## Changelog
+
+### 1.3.0
+- Added option to enable rounded corners for video thumbnails

--- a/layouts/shortcodes/yt.html
+++ b/layouts/shortcodes/yt.html
@@ -8,6 +8,10 @@
   background-color: #000;
 }
 
+.video-wrapper.rounded-corners {
+  border-radius: 10px;
+}
+
 .video-thumbnail {
   position: absolute;
   width: 100%;
@@ -30,6 +34,10 @@
   padding: 0.5em 1em;
   z-index: 2;
   pointer-events: none;
+}
+
+.video-wrapper.rounded-corners .video-overlay {
+  border-radius: 0 0 10px 10px;
 }
 
 .video-play-button {
@@ -68,7 +76,7 @@
 }
 </style>
 
-<div class="video-wrapper{{ with .Site.Params.youtube_video_class }} {{ . }}{{ end }}" data-video-id="{{ .Get 0 }}">
+<div class="video-wrapper{{ with .Site.Params.youtube_video_class }} {{ . }}{{ end }}{{ if eq .Site.Params.rounded_thumbnails true }} rounded-corners{{ end }}" data-video-id="{{ .Get 0 }}">
   <img
     class="video-thumbnail"
     src="https://img.youtube.com/vi/{{ .Get 0 }}/maxresdefault.jpg"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mbplugin-youtube-nocookie",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mbplugin-youtube-nocookie",
-      "version": "1.0.0",
+      "version": "1.3.0",
       "license": "ISC",
       "devDependencies": {
         "jest": "^30.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mbplugin-youtube-nocookie",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "description": "<img src=\"yt-nocookie-logo.png\" alt=\"YouTube Nocookie Plugin Logo\" width=\"200\">",
   "main": "index.js",
   "scripts": {

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0",
+  "version": "1.3.0",
   "title": "YouTube Nocookie Embed (Lazy)",
   "description": "Embeds YouTube videos using youtube-nocookie.com with a privacy-friendly click-to-play overlay and optional privacy message.",
   "fields": [
@@ -19,6 +19,12 @@
       "label": "YouTube privacy notice text",
       "type": "string",
       "default": "Click to load video from YouTube. Personal data may be transferred."
+    },
+    {
+      "field": "params.rounded_thumbnails",
+      "label": "Rounded thumbnail corners",
+      "type": "boolean",
+      "default": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- allow rounded corners on video previews via new `rounded_thumbnails` option
- document rounded thumbnail option and changelog
- bump version to 1.3.0

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c04c97ff4083288d1840523012b9a0