### PR TITLE
Ensure feed thumbnail link targets video watch URL

### DIFF
--- a/layouts/shortcodes/yt.html
+++ b/layouts/shortcodes/yt.html
@@ -584,10 +584,10 @@
 
 {{- /* Generate YouTube link for fallback */ -}}
 {{- $videoLink := "" -}}
-{{- if $playlistID -}}
-  {{- $videoLink = printf "https://www.youtube.com/playlist?list=%s" $playlistID -}}
-{{- else if $videoID -}}
+{{- if $videoID -}}
   {{- $videoLink = printf "https://www.youtube.com/watch?v=%s" $videoID -}}
+{{- else if $playlistID -}}
+  {{- $videoLink = printf "https://www.youtube.com/playlist?list=%s" $playlistID -}}
 {{- end -}}
 
 {{- /* Determine fallback thumbnail */ -}}
@@ -638,6 +638,16 @@
       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
       allowfullscreen
       loading="lazy"></iframe>
+  {{- end -}}
+  {{- /* Linked thumbnail fallback for feed readers */ -}}
+  {{- if and $videoLink $fallbackThumb -}}
+    <p>
+      <a href="{{ $videoLink | safeURL }}">
+        <img
+          src="{{ $fallbackThumb | safeURL }}"
+          alt="{{ if ne $videoTitle "" }}Thumbnail for video: {{ $videoTitle }}{{ else if $playlistID }}YouTube playlist thumbnail{{ else }}YouTube video thumbnail{{ end }}">
+      </a>
+    </p>
   {{- end -}}
   {{- /* Fallback link for feed readers that strip iframes */ -}}
   {{- if $videoLink -}}


### PR DESCRIPTION
## Summary
- prefer the direct YouTube watch URL when building the feed fallback link so linked thumbnails point to the actual video

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6907e220d2f083289b2dc9fa9f61cfd1