### PR TITLE
Detect feeds by comparing known output permalinks

### DIFF
--- a/layouts/shortcodes/yt.html
+++ b/layouts/shortcodes/yt.html
@@ -1,34 +1,33 @@
 {{- $includeAssets := true -}}
 {{- $isFeed := false -}}
+
 {{- with .Page -}}
-  {{- $outputFormatName := "" -}}
-  {{- with .OutputFormat -}}
-    {{- with .Name -}}
-      {{- $outputFormatName = lower . -}}
-    {{- else -}}
-      {{- with .MediaType -}}
-        {{- with .Type -}}
-          {{- $outputFormatName = lower . -}}
-        {{- end -}}
-      {{- end -}}
-    {{- end -}}
-  {{- end -}}
+  {{- $page := . -}}
   {{- if .Scratch.Get "yt-nocookie-assets" -}}
     {{- $includeAssets = false -}}
   {{- else -}}
     {{- .Scratch.Set "yt-nocookie-assets" true -}}
   {{- end -}}
   {{- $permalink := "" -}}
+  {{- $relPermalink := "" -}}
   {{- with .RelPermalink -}}
     {{- $permalink = . -}}
+    {{- $relPermalink = . -}}
   {{- end -}}
   {{- if eq $permalink "" -}}
     {{- with .Permalink -}}
       {{- $permalink = . -}}
     {{- end -}}
   {{- end -}}
-  {{- if or (eq $outputFormatName "rss") (eq $outputFormatName "atom") (eq $outputFormatName "json") -}}
-    {{- $isFeed = true -}}
+  {{- /* Compare current permalink with known feed outputs */ -}}
+  {{- $feedFormats := slice "rss" "atom" "json" -}}
+  {{- range $feedFormats -}}
+    {{- $formatName := upper . -}}
+    {{- with $page.OutputFormats.Get $formatName -}}
+      {{- if or (and (ne $permalink "") (eq $permalink .Permalink)) (and (ne $relPermalink "") (eq $relPermalink .RelPermalink)) -}}
+        {{- $isFeed = true -}}
+      {{- end -}}
+    {{- end -}}
   {{- end -}}
   {{- if not $isFeed -}}
     {{- $permalinkLower := lower $permalink -}}


### PR DESCRIPTION
## Summary
- detect feed rendering by comparing the current permalink with the page's feed output permalinks
- keep the permalink suffix fallback so feeds without standard names continue to work

## Testing
- not run (hugo executable not available in environment)

------
https://chatgpt.com/codex/tasks/task_e_6907e3dba15083288dfb92f84b1be450